### PR TITLE
Add commands for changing voices for the speech functionality in OS X.

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -49,6 +49,28 @@ module BettyConfig
       }
     end
 
+    if command.match(/^(list\s(your\s)?voices)/i)
+      responses << {
+        :command => 'say -v "?"',
+        :explanation => 'List the availables voices for text-to-speech.'
+      }
+    end
+
+    if command.match(/^(?:set|change|make)\s+(?:your|betty\'?s?)\s+voice\s+to\s+(.+)$/i)
+      new_voice = $1.strip
+      responses << {
+        :call_before => lambda { self.set("voice", new_voice) },
+        :say => "OK. My new voice is #{ new_voice } from now on."
+      }
+    end
+
+    if command.match(/^what\'?s?(?:\s+is)?\s+your\s+voice\??$/i)
+      my_voice = self.get("voice")
+      responses << {
+        :say => "My voice is setted as #{ my_voice }."
+      }
+    end
+
     if command.match(/^(?:set|change|make)\s+(?:your|betty\'?s?)\s+name\s+to\s+(.+)$/i) || command.match(/^stop\s+speak(ing)?\s+to\s+me$/)
       new_name = $1.strip
       responses << {

--- a/main.rb
+++ b/main.rb
@@ -71,7 +71,9 @@ end
 
 def speak(text)
   if User.has_command?('say')
-    system("say \"#{ text }\"") # formerly mpg123 -q
+    say = 'say'
+    say += " -v '#{BettyConfig.get("voice")}'" if BettyConfig.get("voice")
+    system("#{say} \"#{ text }\"") # formerly mpg123 -q
   else
     has_afplay = User.has_command?('afplay')
     has_mpg123 = User.has_command?('mpg123')


### PR DESCRIPTION
This PR add 3 new configuration commands that allow to change Betty's voice in OS X when text-to-speech is enabled.

```
betty list your voices
betty change your voice to Zarvox # or any other previously listed voice, no quotes needed
betty what is your voice
```

Refactoring or any other kind of suggestions are welcomed!
