### PR TITLE
Correct usage

### DIFF
--- a/lib/translate.rb
+++ b/lib/translate.rb
@@ -23,7 +23,7 @@ module Translate
     commands << {
       :category => "Translate",
       :description => '\033[34mTranslate\033[0m',
-      :usage =>["- betty translate from English to Spanish"]
+      :usage =>["- betty translate from en to es"]
     }
     commands
   end


### PR DESCRIPTION
Google Translate uses 2 letter ISO codes for language names, not natural language names.
