### PR TITLE
Easier platform management and added support for translation and spotify...

### DIFF
--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -1,0 +1,38 @@
+module Command
+
+  @@platform_error = "echo \"I don\'t know how to do that on #{OS.platform_name} yet, sorry !\""
+
+  #todo: complete for missing OSes
+  def self.browser(link)
+    browser = ""
+    case OS.platform_name
+      when 'Mac OS'
+        browser = 'open'
+      when 'Linux'
+        browser = 'xdg-open'
+      when 'Windows'
+        browser = 'start'
+      else
+        return @@platform_error
+    end
+    return "#{browser} #{link}"
+  end
+
+  def self.bus(msg= {})
+    case OS.platform_name
+      when 'Mac OS'
+        if ! msg[:osx]
+          return @@platform_error
+        end
+        return "osascript -e '#{msg[:osx]}'"
+      when 'Linux'
+        if ! msg[:linux]
+          return @@platform_error
+        end
+        return "dbus-send #{msg[:linux]}"
+      else
+        return @@platform_error
+      end
+  end
+end
+

--- a/lib/itunes.rb
+++ b/lib/itunes.rb
@@ -4,7 +4,7 @@ module ITunes
     is_unmute = matching && matching[1] == "un"
     if matching
       {
-        :command => "osascript -e 'tell application \"iTunes\" to set mute to #{ !is_unmute }'",
+        :command => Command.bus({:osx => "tell application \"iTunes\" to set mute to #{ !is_unmute }"}),
         :explanation => "#{ is_unmute ? 'Unmutes' : 'Mutes' } iTunes."
       }
     else
@@ -17,7 +17,7 @@ module ITunes
 
     if matching
       {
-        :command => "osascript -e 'tell application \"iTunes\" to stop'",
+        :command => Command.bus({:osx => "tell application \"iTunes\" to stop"}),
         :explanation => "Stops playing iTunes."
       }
     else
@@ -30,7 +30,7 @@ module ITunes
 
     if matching
       {
-        :command => "osascript -e 'tell application \"iTunes\" to play'",
+        :command => Command.bus({:osx => "tell application \"iTunes\" to play"}),
         :explanation => "Starts playing iTunes."
       }
     else
@@ -43,7 +43,7 @@ module ITunes
 
     if matching
       {
-        :command => "osascript -e 'tell application \"iTunes\" to pause'",
+        :command => Command.bus({:osx => "tell application \"iTunes\" to pause"}),
         :explanation => "Pauses iTunes."
       }
     else
@@ -56,7 +56,7 @@ module ITunes
 
     if matching
       {
-        :command => "osascript -e 'tell application \"iTunes\" to next track'",
+        :command => Command.bus({:osx => "tell application \"iTunes\" to next track"}),
         :explanation => "Makes iTunes play the next track."
       }
     else
@@ -69,7 +69,7 @@ module ITunes
 
     if matching
       {
-        :command => "osascript -e 'tell application \"iTunes\" to previous track'",
+        :command => Command.bus({:osx => "tell application \"iTunes\" to previous track"}),
         :explanation => "Makes iTunes play the previous track."
       }
     else
@@ -82,7 +82,7 @@ module ITunes
 
     if matching
       {
-        :command => "osascript -e 'tell application \"iTunes\" to get name of current track'",
+        :command => Command.bus({:osx => "tell application \"iTunes\" to get name of current track"}),
         :explanation => "Gets the name of the playing track on iTunes."
       }
     else

--- a/lib/map.rb
+++ b/lib/map.rb
@@ -4,19 +4,9 @@ module Map
 
     if command.match(/^(?:show\s+)?(?:me\s+)?(?:a\s+)?map\s+(?:of\s+)?(.+)$/)
       search_term = $1.gsub(' ', '%20')
-      command = ""
-
-      case OS.platform_name
-        when 'Mac OS'
-          command = 'open'
-        when 'Linux'
-          command = 'xdg-open'
-        when 'Windows'
-          command = 'start'
-      end
 
       responses << {
-        :command => "#{command} https://www.google.com/maps/search/#{ search_term }",
+        :command => Command.browser("https://www.google.com/maps/search/#{ search_term }"),
         :explanation => "Opens a browser with Google Maps searching for '#{ search_term }'."
       }
     end

--- a/lib/spotify.rb
+++ b/lib/spotify.rb
@@ -5,7 +5,13 @@ module Spotify
 
     if matching
       {
-        :command => "osascript -e 'tell application \"spotify\" to play'",
+        msg = 
+        :command => Command.bus({
+          :osx => "tell application \"spotify\" to play",
+          :linux => "--print-reply --dest=org.mpris.MediaPlayer2.spotify" \
+          +         " /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.PlayPause"\
+          +         " >/dev/null"
+        }),
         :explanation => "Starts playing spotify."
       }
     else
@@ -18,7 +24,12 @@ module Spotify
 
     if matching
       {
-        :command => "osascript -e 'tell application \"spotify\" to pause'",
+        :command => Command.bus({
+          :osx => "tell application \"spotify\" to pause",
+          :linux => "--print-reply --dest=org.mpris.MediaPlayer2.spotify" \
+          +         " /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Pause"\
+          +         " >/dev/null"
+        }),
         :explanation => "Pauses spotify."
       }
     else
@@ -31,7 +42,12 @@ module Spotify
 
     if matching
       {
-        :command => "osascript -e 'tell application \"spotify\" to next track'",
+        :command => Command.bus({
+          :osx => "tell application \"spotify\" to next track",
+          :linux => "--print-reply --dest=org.mpris.MediaPlayer2.spotify" \
+          +         " /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Next"\
+          +         " >/dev/null"
+        }),
         :explanation => "Makes spotify play the next track."
       }
     else
@@ -44,7 +60,13 @@ module Spotify
 
     if matching
       {
-        :command => "osascript -e 'tell application \"spotify\" to previous track'",
+        :command => Command.bus({
+          :osx => "tell application \"spotify\" to previous track",
+          :linux => "--print-reply --dest=org.mpris.MediaPlayer2.spotify" \
+          +         " /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Previous"\
+          +         " >/dev/null"
+        }),
+
         :explanation => "Makes spotify play the previous track."
       }
     else

--- a/lib/translate.rb
+++ b/lib/translate.rb
@@ -10,7 +10,7 @@ module Translate
       to = matches[3].strip
 
       responses << {
-        :command => "open https://translate.google.com/##{from}/#{to}/#{translate_string}",
+        :command => Command.browser("https://translate.google.com/##{from}/#{to}/#{translate_string}"),
         :explanation => "Opens a browser on Google Translate translating #{translate_string} from #{from} to #{to}."
       }
     end


### PR DESCRIPTION
... on Linux

To open a link in a browser, just use Command.browser(link), and it will work on Mac, Linux and Windows (and eventually on the others).

To use interprocess communication (like dbus or osascript), use Command.bus(script). The script should be like : {osx:"script on osx", linux:"script on linux"}.

See the examples in spotify.rb for more info
