### PR TITLE
Pod bay doors added to Fun module

### DIFF
--- a/lib/fun.rb
+++ b/lib/fun.rb
@@ -8,6 +8,12 @@ module Fun
       }
     end
     
+    if command.match(/^open\s(the\s)?pod\sbay\sdoor(s)?$/i)
+      responses << {
+        :say => "I'm sorry, Dave. I'm afraid I can't do that."
+      }
+    end
+    
     if command.match(/^make\s+me\s+a\s+(.+)$/i)
       thing = "#{ $1 }"
       responses << {


### PR DESCRIPTION
I've added "open the pod bay doors" command which resembles Space Odyssey 2001. Not sure about the name, maybe it's better to change "Dave" into `whoami` output, but I've decided to keep citation consistent.

Switched this to dev branch.
