### PR TITLE
Removed non-functioning "go home" command.

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -23,7 +23,7 @@ if CONTINUE == "" || CONTINUE == "y"
     if Dir.exist? INSTALL_LOC
       # raise "~/betty already exists! Please manually remove if you want to proceed" 
     else
-      COPY_COMMAND = 'cp -rf ' + Dir.pwd + ' ' + INSTALL_LOC
+      COPY_COMMAND = 'cp -rf ' + File.dirname(__FILE__) + ' ' + INSTALL_LOC
       print "Running `" + COPY_COMMAND + "`\n"
       system COPY_COMMAND 
     end

--- a/lib/fun.rb
+++ b/lib/fun.rb
@@ -59,12 +59,6 @@ module Fun
       }
     end
     
-    if command.match(/go home/)
-      responses << {
-        :command => "cd ~"
-      }
-    end
-    
     if command.match(/sing (.*)/)
       responses << {
         :command => "say -v cello #{$~}"


### PR DESCRIPTION
Address #177 by removing the "go home" command since there does not appear be a way to make it work.