### PR TITLE
Text-to-speech management (fixes #197, #170)

### DIFF
--- a/lib/fun.rb
+++ b/lib/fun.rb
@@ -53,9 +53,15 @@ module Fun
     end
     
     if command.match(/sing (.*)/)
-      responses << {
-        :command => "say -v cello #{$~}"
-      }
+        if User.has_command?('say')
+            responses << {
+                :command => "say -v cello #{$~}"
+            }
+        else
+            responses << {
+                :say => "I don't have my singing voice today (the program 'say' would help me get one)."
+            }
+        end
     end
     
     responses

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -1,6 +1,6 @@
 module User  
   def self.has_command?(command)
-    response = `which #{ command }`
+    response = `which #{ command } 2>/dev/null`
     response != ""
   end
 


### PR DESCRIPTION
* Redirects the STDERR output of `where` command used in `User.has_command?` check. We deal with the result inside the program anyway, so error messages like in #170 and #197 are unnecessary. 

* Checks that a known text-to-speech program is available before turning speech ON. 

* Checks for command availability before performing various voice-related actions. For eg., currently `betty list your voices` when run in a system without the `say` command gives the output:

```
Betty: Running say -v "?"
sh: say: command not found

```
whereas with these changes, `betty list your voices` returns: 

`Betty: I don't seem to have a voice at all (the program 'say' would help me get some).`

* Some minor cleanup of the `speak()` function

